### PR TITLE
Fix typo in Device Auth Endpoint docs

### DIFF
--- a/docs/client/device_authorize.rst
+++ b/docs/client/device_authorize.rst
@@ -23,5 +23,5 @@ Before using the response, you should always check the ``IsError`` property to m
 
     var userCode = response.UserCode;
     var deviceCode = response.DeviceCode;
-    var verificationUrl = response.VerificationUri";
+    var verificationUrl = response.VerificationUri;
     var verificationUrlComplete = response.VerificationUriComplete;


### PR DESCRIPTION
Removes typo (`"`) from https://github.com/IdentityModel/Documentation/blob/master/docs/client/device_authorize.rst