### PR TITLE
Updated URL for IBrowser interface

### DIFF
--- a/docs/native/automatic.rst
+++ b/docs/native/automatic.rst
@@ -1,6 +1,6 @@
 Automatic Mode
 ==============
-In automatic mode, you can encapsulate all browser interactions by implementing the `IBrowser <https://github.com/IdentityModel/IdentityModel.OidcClient/blob/master/src/Browser/IBrowser.cs/>`_ interface::
+In automatic mode, you can encapsulate all browser interactions by implementing the `IBrowser <https://github.com/IdentityModel/IdentityModel.OidcClient/blob/main/src/OidcClient/Browser/IBrowser.cs>`_ interface::
 
     var options = new OidcClientOptions
     {


### PR DESCRIPTION
Current documentation is pointing to URL for IBrowser interface which does not exist.